### PR TITLE
Add pre-commit hook running gofmt

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script runs gofmt on all staged files to ensure proper formatting.
+# Any detected errors will be printed to stdout and the commit aborted.
+
+# NOTE: This script probably won't work for partial changes added with
+# git add -p or git commit -p.
+
+command -v gofmt >/dev/null 2>&1 || { echo >&2 "gofmt not on PATH."; exit 1; }
+
+git stash -q --keep-index >/dev/null
+
+IFS='\n'
+exitcode=0
+for file in $(git diff --staged --name-only --diff-filter=ACMR | grep '\.go$')
+do
+    output=`gofmt -w=true "$file"`
+    if [ -n $output ]
+    then
+            # any output is a syntax error
+        echo >&2 "$output"
+        exitcode=1
+    fi
+    git add "$file"
+done
+
+git stash pop -q >/dev/null 2>&1
+
+exit $exitcode


### PR DESCRIPTION
This pre-commit hook runs gofmt on all staged .go files.  If any syntax errors are encountered they are printed to stdout and the commit aborted.  Any non-standard formatting is changed to the recommended style.

The Go emacs mode, and I assume those of other editors too, are imperfect in terms of indentation.  Thus running gofmt on all files is good practice.

The pre-commit hook is activated by running:

``` bash
ln -s ../../pre-commit.sh .git/hooks/pre/commit
```

in the repo.
